### PR TITLE
Add progress flag and CSV output

### DIFF
--- a/codex-replay.md
+++ b/codex-replay.md
@@ -1,2 +1,13 @@
 # Codex Replay Log
 
+`CodexResearcher` records every candidate mnemonic in this markdown file and a
+companion CSV named `codex-replay.csv`.
+
+CSV columns are:
+
+```
+attempt,prefix_len,hamming_distance,similarity
+```
+
+Use `--progress` on the CLI to print live updates whenever a better zpub
+similarity is found. Progress output disables Rayon parallelism for clarity.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@ pub struct CliArgs {
     pub share2: String,
     pub zpub: Option<String>,
     pub threads: Option<usize>,
+    pub progress: bool,
 }
 
 impl CliArgs {
@@ -26,6 +27,7 @@ impl CliArgs {
         let mut share2 = None;
         let mut zpub = None;
         let mut threads = None;
+        let mut progress = false;
 
         while let Some(arg) = args.next() {
             match arg.as_str() {
@@ -39,6 +41,9 @@ impl CliArgs {
                         return Err("--threads requires value".into());
                     }
                 }
+                "--progress" => {
+                    progress = true;
+                }
                 other => return Err(format!("unknown arg: {}", other)),
             }
         }
@@ -46,7 +51,7 @@ impl CliArgs {
         let share1 = share1.ok_or("--share1 required")?;
         let share2 = share2.ok_or("--share2 required")?;
 
-        Ok(CliArgs { share1, share2, zpub, threads })
+        Ok(CliArgs { share1, share2, zpub, threads, progress })
     }
 
     /// Load a mnemonic either from inline string or from file path.
@@ -71,5 +76,6 @@ mod tests {
         let parsed = CliArgs::parse_from(args.into_iter().map(String::from)).unwrap();
         assert_eq!(parsed.share1, "a");
         assert_eq!(parsed.share2, "b");
+        assert!(!parsed.progress);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ pub struct Config {
     pub share1: String,
     pub share2: String,
     pub zpub: Option<String>,
+    pub progress: bool,
 }
 
 impl Default for Config {
@@ -15,6 +16,7 @@ impl Default for Config {
             share1: String::new(),
             share2: String::new(),
             zpub: None,
+            progress: false,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub fn run(cfg: config::Config) {
 
     let zpub = cfg.zpub.as_deref().unwrap_or("");
     let researcher = agents::codex_researcher::CodexResearcher::new("codex-replay.md");
-    let result = search::brute::brute_force_third_share(&s1, &s2, zpub, cfg.max_depth, Some(&researcher));
+    let result = search::brute::brute_force_third_share(&s1, &s2, zpub, cfg.max_depth, Some(&researcher), cfg.progress);
 
     if let Some((_, mnemonic)) = result {
         let derived = bip39::seed::derive_seed_zpub(&mnemonic).unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ fn main() {
     cfg.share1 = args.share1;
     cfg.share2 = args.share2;
     cfg.zpub = args.zpub;
+    cfg.progress = args.progress;
     if let Some(t) = args.threads { cfg.threads = t; }
     msrs::run(cfg);
 }

--- a/src/search/brute.rs
+++ b/src/search/brute.rs
@@ -27,15 +27,55 @@ pub fn brute_force_third_share(
     expected_zpub: &str,
     max_depth: usize,
     log: Option<&CodexResearcher>,
+    show_progress: bool,
 ) -> Option<(Vec<u8>, String)> {
     assert_eq!(share_a.len(), share_b.len(), "share length mismatch");
     assert!(share_a.len() > 1, "shares must include payload");
     assert!(share_a[0] != share_b[0], "duplicate share indexes");
 
     let payload_len = share_a.len() - 1;
-
     let heuristics_first = candidate_queue(share_a, share_b, max_depth, 256);
-    if let Some(found) = heuristics_first.into_par_iter().find_map_any(|data| {
+    let mut best_similarity = 0.0f64;
+    if show_progress {
+        for data in heuristics_first {
+            for idx in 1u8..=255 {
+                if idx == share_a[0] || idx == share_b[0] {
+                    continue;
+                }
+
+                let mut share_c = Vec::with_capacity(payload_len + 1);
+                share_c.push(idx);
+                share_c.extend_from_slice(&data);
+
+                if let Ok(secret) = attempt_reconstruction(share_a, share_b, &share_c) {
+                    if secret.len() != 16 {
+                        continue;
+                    }
+                    if let Ok(words) = entropy_to_mnemonic(&secret) {
+                        let mnemonic = words.join(" ");
+                        let cand_z = crate::bip39::seed::derive_seed_zpub(&mnemonic).unwrap_or_default();
+                        let diff = zpub_diff(&cand_z, expected_zpub);
+                        if diff.similarity > best_similarity {
+                            best_similarity = diff.similarity;
+                            println!("[Progress] best similarity {:.4}", best_similarity);
+                        }
+                        if let Ok(true) = derive_seed(&mnemonic, expected_zpub) {
+                            println!(
+                                "[+] Found candidate idx={} payload={} mnemonic={}",
+                                idx,
+                                hexify(&data),
+                                mnemonic
+                            );
+                            return Some((share_c, mnemonic));
+                        } else if let Some(r) = log {
+                            let path_str = format!("{}/{}/{}", share_a[0], share_b[0], idx);
+                            let _ = r.record_attempt(&mnemonic, &cand_z, expected_zpub, &secret, &path_str, diff);
+                        }
+                    }
+                }
+            }
+        }
+    } else if let Some(found) = heuristics_first.into_par_iter().find_map_any(|data| {
         for idx in 1u8..=255 {
             if idx == share_a[0] || idx == share_b[0] {
                 continue;
@@ -63,7 +103,7 @@ pub fn brute_force_third_share(
                         return Some((share_c, mnemonic));
                     } else if let Some(r) = log {
                         let path_str = format!("{}/{}/{}", share_a[0], share_b[0], idx);
-                        let _ = r.record_attempt(&mnemonic, &cand_z, expected_zpub, &secret, &path_str, diff.similarity);
+                        let _ = r.record_attempt(&mnemonic, &cand_z, expected_zpub, &secret, &path_str, diff);
                     }
                 }
             }
@@ -73,14 +113,65 @@ pub fn brute_force_third_share(
         return Some(found);
     }
 
-    (0..max_depth).into_par_iter().find_map_any(|candidate| {
-        // why: enumerate candidate payloads as a little-endian counter
-        let mut data = vec![0u8; payload_len];
-        let mut tmp = candidate;
-        for b in data.iter_mut() {
-            *b = (tmp & 0xff) as u8;
-            tmp >>= 8;
+    if show_progress {
+        for candidate in 0..max_depth {
+            // why: enumerate candidate payloads as a little-endian counter
+            let mut data = vec![0u8; payload_len];
+            let mut tmp = candidate;
+            for b in data.iter_mut() {
+                *b = (tmp & 0xff) as u8;
+                tmp >>= 8;
+            }
+
+            for idx in 1u8..=255 {
+                if idx == share_a[0] || idx == share_b[0] {
+                    continue;
+                }
+
+                let mut share_c = Vec::with_capacity(payload_len + 1);
+                share_c.push(idx);
+                share_c.extend_from_slice(&data);
+
+                if let Ok(secret) = attempt_reconstruction(share_a, share_b, &share_c) {
+                    if secret.len() != 16 {
+                        continue;
+                    }
+
+                    if let Ok(words) = entropy_to_mnemonic(&secret) {
+                        let mnemonic = words.join(" ");
+
+                        let cand_z = crate::bip39::seed::derive_seed_zpub(&mnemonic).unwrap_or_default();
+                        let diff = zpub_diff(&cand_z, expected_zpub);
+                        if diff.similarity > best_similarity {
+                            best_similarity = diff.similarity;
+                            println!("[Progress] best similarity {:.4}", best_similarity);
+                        }
+                        if let Ok(true) = derive_seed(&mnemonic, expected_zpub) {
+                            println!(
+                                "[+] Found candidate idx={} payload={} mnemonic={}",
+                                idx,
+                                hexify(&data),
+                                mnemonic
+                            );
+                            return Some((share_c, mnemonic));
+                        } else if let Some(r) = log {
+                            let path_str = format!("{}/{}/{}", share_a[0], share_b[0], idx);
+                            let _ = r.record_attempt(&mnemonic, &cand_z, expected_zpub, &secret, &path_str, diff);
+                        }
+                    }
+                }
+            }
         }
+        None
+    } else {
+        (0..max_depth).into_par_iter().find_map_any(|candidate| {
+            // why: enumerate candidate payloads as a little-endian counter
+            let mut data = vec![0u8; payload_len];
+            let mut tmp = candidate;
+            for b in data.iter_mut() {
+                *b = (tmp & 0xff) as u8;
+                tmp >>= 8;
+            }
 
         for idx in 1u8..=255 {
             if idx == share_a[0] || idx == share_b[0] {
@@ -112,13 +203,14 @@ pub fn brute_force_third_share(
                         return Some((share_c, mnemonic));
                     } else if let Some(r) = log {
                         let path_str = format!("{}/{}/{}", share_a[0], share_b[0], idx);
-                        let _ = r.record_attempt(&mnemonic, &cand_z, expected_zpub, &secret, &path_str, diff.similarity);
+                        let _ = r.record_attempt(&mnemonic, &cand_z, expected_zpub, &secret, &path_str, diff);
                     }
                 }
             }
         }
         None
     })
+    }
 }
 
 /// Placeholder wrapper used by the CLI. Real parameters will be wired up later.
@@ -167,6 +259,7 @@ mod tests {
             &zpub,
             candidate_num + 1,
             None,
+            false,
         )
         .expect("should find share");
 


### PR DESCRIPTION
## Summary
- log DiffMetrics to CSV in `codex_researcher`
- add `--progress` CLI option and wire through configuration
- print best zpub similarity in sequential mode
- document new `codex-replay.csv` output

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68426e60f828832694d84a84f7404940